### PR TITLE
fix: bust SDK internal model cache on picker refresh

### DIFF
--- a/src/commands/model-catalog.test.ts
+++ b/src/commands/model-catalog.test.ts
@@ -127,6 +127,30 @@ describe("loadModelCatalog", () => {
     expect(listModelsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("busts SDK internal model cache on forced refresh", async () => {
+    const mockClient = { listModels: listModelsMock, modelsCache: ["stale-entry"] };
+    listModelsMock.mockResolvedValue([createModel("gpt-5.4-mini", "GPT-5.4 Mini")]);
+    getClientMock.mockReturnValue(mockClient);
+
+    const { loadModelCatalog } = await import("./model-catalog");
+    const result = await loadModelCatalog({ forceRefresh: true });
+
+    expect(mockClient.modelsCache).toBeNull();
+    expect(result.source).toBe("network");
+    expect(result.models[0].id).toBe("gpt-5.4-mini");
+  });
+
+  it("does not bust SDK cache on normal load", async () => {
+    const mockClient = { listModels: listModelsMock, modelsCache: ["stale-entry"] };
+    listModelsMock.mockResolvedValue([createModel("gpt-5.4", "GPT-5.4")]);
+    getClientMock.mockReturnValue(mockClient);
+
+    const { loadModelCatalog } = await import("./model-catalog");
+    await loadModelCatalog();
+
+    expect(mockClient.modelsCache).toEqual(["stale-entry"]);
+  });
+
   it("falls back to stale cache when SDK refresh fails", async () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(

--- a/src/commands/model-catalog.ts
+++ b/src/commands/model-catalog.ts
@@ -80,10 +80,16 @@ function normalizeModel(value: ModelInfo): AvailableModel | null {
   };
 }
 
-async function fetchModelCatalogFromCopilot(): Promise<ModelCatalogCache> {
+async function fetchModelCatalogFromCopilot(forceRefresh = false): Promise<ModelCatalogCache> {
   const client = getClient();
   if (!client) {
     throw new Error("Copilot client is not started");
+  }
+
+  if (forceRefresh) {
+    // SDK caches models for the client's lifetime with no public invalidation API.
+    // Null out the private cache so listModels() re-fetches from the server.
+    (client as unknown as Record<string, unknown>).modelsCache = null;
   }
 
   const payload = await client.listModels();
@@ -121,7 +127,7 @@ export async function loadModelCatalog(options?: {
   }
 
   try {
-    const fresh = await fetchModelCatalogFromCopilot();
+    const fresh = await fetchModelCatalogFromCopilot(options?.forceRefresh);
     await writeModelCatalogCache(fresh);
     return {
       fetchedAt: fresh.fetchedAt,


### PR DESCRIPTION
## Summary

- The model picker's Refresh button bypassed Neo's file cache (`copilot-models-cache.json`) but still hit the Copilot SDK's in-memory `modelsCache`, which persists for the client's lifetime with no public invalidation API
- New models added server-side would never appear in the picker until a full Neo restart
- Fix: null out the SDK's private `modelsCache` field before calling `listModels()` when `forceRefresh` is requested

## Test plan

- [x] New test: verifies SDK cache is nulled on forced refresh
- [x] New test: verifies SDK cache is untouched on normal loads
- [x] All 210 existing tests pass
- [x] Lint, format, typecheck clean