### PR TITLE
Feat: add BYOK provider model support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,17 @@ TELEGRAM_OWNER_ID=            # Your Telegram user ID (from @userinfobot)
 # GitHub Copilot
 GITHUB_TOKEN=                 # GitHub PAT with Copilot access
 
+# BYOK providers (optional) — set API keys to enable additional model providers
+ANTHROPIC_API_KEY=            # Anthropic API key (enables Claude models via direct API)
+OPENAI_API_KEY=               # OpenAI API key (enables GPT models via direct API)
+
+# Custom provider (optional) — for Ollama, Azure, or other OpenAI-compatible endpoints
+NEO_PROVIDER_NAME=            # Display name (e.g., "ollama")
+NEO_PROVIDER_TYPE=            # Provider type: openai or anthropic
+NEO_PROVIDER_BASE_URL=        # API base URL (e.g., http://localhost:11434/v1)
+NEO_PROVIDER_API_KEY=         # API key (optional for local providers)
+NEO_PROVIDER_BEARER_TOKEN=    # Bearer token (takes precedence over API key)
+
 # Optional
 DEEPGRAM_API_KEY=             # Enable voice transcription
 NEO_BROWSER_HEADLESS=true     # Default browser mode for Playwright sessions

--- a/PLANNED-FEATURES.md
+++ b/PLANNED-FEATURES.md
@@ -43,7 +43,7 @@ Implemented. Removed the 5-minute hard timeout — jobs now run to completion, l
 Revisit as needs evolve or the SDK stabilizes.
 
 - [ ] **`onUserPromptSubmitted`** — Per-turn dynamic context injection. Deferred because `onSessionStart` already covers the primary use case: daily memory is too expensive for per-turn injection (and the model can use the `memory` tool for live reads), while runtime state and anomalies rarely change mid-session. Revisit when a concrete per-turn need arises (smart model routing, multi-user permission context, prompt augmentation).
-- [ ] **BYOK / `ProviderConfig`** — Fall back to a self-hosted model when Copilot quota runs out. Needs quota detection.
+- [x] **BYOK / `ProviderConfig`** — Multi-provider model access. Set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` to enable additional providers. Models appear in the `/model` picker with provider tags (e.g., `[anthropic]`, `[copilot]`). Custom OpenAI-compatible endpoints (Ollama, etc.) supported via `NEO_PROVIDER_*` env vars. Provider changes trigger session refresh. Auto-fallback on quota exhaustion is out of scope for now.
 - [ ] **Telemetry / `TelemetryConfig`** — OTLP export for observability beyond SQLite audit logs.
 - [ ] **`cliUrl`** — Connect to a remote CLI server instead of managing the process locally.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,33 @@ Neo auto-compacts long conversations before they fall out of context. Session su
 
 Send a voice message in Telegram and Neo will transcribe it via Deepgram and respond. Requires `DEEPGRAM_API_KEY` in `.env`.
 
+## BYOK (Bring Your Own Key)
+
+Neo supports multiple model providers alongside GitHub Copilot. Set API keys in `.env` to enable additional providers — their models appear in the `/model` picker with provider tags.
+
+**Quick setup:**
+
+```bash
+# Add to .env — models from these providers appear automatically
+ANTHROPIC_API_KEY=sk-ant-...    # Enables Claude models via Anthropic API
+OPENAI_API_KEY=sk-...           # Enables GPT models via OpenAI API
+```
+
+**Usage:**
+- `/model` — Picker shows all models tagged with their provider: `claude-opus-4-6 [anthropic]`, `gpt-4.1 [copilot]`
+- `/model anthropic:claude-opus-4-6` — Switch directly using `provider:model` syntax
+- `/whichmodel` — Shows the active provider
+
+**Custom providers** (Ollama, other OpenAI-compatible endpoints):
+
+```bash
+NEO_PROVIDER_NAME=ollama
+NEO_PROVIDER_TYPE=openai
+NEO_PROVIDER_BASE_URL=http://localhost:11434/v1
+```
+
+Switching between providers triggers a session refresh (the SDK's `provider` config is session-level). Switching models within the same provider is instant.
+
 ## Environment Variables
 
 See [`.env.example`](.env.example) for all options.
@@ -192,6 +219,13 @@ See [`.env.example`](.env.example) for all options.
 | `TELEGRAM_BOT_TOKEN`           | Yes      | From @BotFather                                   |
 | `TELEGRAM_OWNER_ID`            | Yes      | Telegram user ID                                  |
 | `GITHUB_TOKEN`                 | Yes      | GitHub PAT with Copilot access                    |
+| `ANTHROPIC_API_KEY`            | No       | Anthropic API key (enables Claude via direct API) |
+| `OPENAI_API_KEY`               | No       | OpenAI API key (enables GPT via direct API)       |
+| `NEO_PROVIDER_NAME`            | No       | Custom provider display name (e.g., "ollama")     |
+| `NEO_PROVIDER_TYPE`            | No       | Custom provider type: `openai` or `anthropic`     |
+| `NEO_PROVIDER_BASE_URL`        | No       | Custom provider API base URL                      |
+| `NEO_PROVIDER_API_KEY`         | No       | Custom provider API key                           |
+| `NEO_PROVIDER_BEARER_TOKEN`    | No       | Custom provider bearer token                      |
 | `DEEPGRAM_API_KEY`             | No       | Enable voice transcription                        |
 | `NEO_BROWSER_HEADLESS`         | No       | Browser mode (default: `true`)                    |
 | `NEO_BROWSER_LAUNCH_ARGS`      | No       | Extra Chromium flags                              |

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -62,6 +62,17 @@ vi.mock("./config.js", () => ({
       root: "/tmp/neo",
       data: "/tmp/neo-data",
     },
+    providers: {
+      anthropicApiKey: undefined,
+      openaiApiKey: undefined,
+      custom: {
+        name: undefined,
+        type: undefined,
+        baseUrl: undefined,
+        apiKey: undefined,
+        bearerToken: undefined,
+      },
+    },
   },
 }));
 
@@ -116,6 +127,15 @@ afterEach(async () => {
   cancelPendingUserInputMock.mockReset();
   cancelAllPendingUserInputsMock.mockReset();
   getChannelConfigMock.mockReset();
+  const { config } = await import("./config.js");
+  config.copilot.model = "gpt-4.1";
+  config.providers.anthropicApiKey = undefined;
+  config.providers.openaiApiKey = undefined;
+  config.providers.custom.name = undefined;
+  config.providers.custom.type = undefined;
+  config.providers.custom.baseUrl = undefined;
+  config.providers.custom.apiKey = undefined;
+  config.providers.custom.bearerToken = undefined;
 });
 
 describe("refreshSessionContext", () => {
@@ -577,6 +597,76 @@ describe("getModelForChat", () => {
     await startAgent();
 
     expect(getModelForChat(-200002)).toBe("gpt-4.1");
+  });
+
+  it("refreshes active default sessions when the default provider changes", async () => {
+    const session = {
+      sessionId: "session-default-provider",
+      setModel: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    };
+    createSessionMock.mockResolvedValue(session);
+    buildSystemContextMock.mockResolvedValue("context");
+    getActiveSessionIdMock.mockReturnValue(null);
+
+    const { config } = await import("./config.js");
+    config.providers.anthropicApiKey = "sk-ant-test";
+
+    const { createNewSession, getSessionForChat, startAgent, switchDefaultModel } =
+      await import("./agent");
+
+    await startAgent();
+    await createNewSession({ chatId: -200005 });
+    await switchDefaultModel("anthropic:claude-opus-4-6");
+
+    expect(session.setModel).not.toHaveBeenCalled();
+    expect(session.disconnect).toHaveBeenCalledTimes(1);
+    expect(deleteSessionMock).toHaveBeenCalledWith("session-default-provider");
+    expect(getSessionForChat(-200005)).toBeUndefined();
+  });
+
+  it("switches active default sessions in place when the provider stays the same", async () => {
+    const session = {
+      sessionId: "session-default-model",
+      setModel: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    };
+    createSessionMock.mockResolvedValue(session);
+    buildSystemContextMock.mockResolvedValue("context");
+    getActiveSessionIdMock.mockReturnValue(null);
+
+    const { createNewSession, startAgent, switchDefaultModel } = await import("./agent");
+
+    await startAgent();
+    await createNewSession({ chatId: -200006 });
+    await switchDefaultModel("gpt-5.4");
+
+    expect(session.setModel).toHaveBeenCalledWith("gpt-5.4");
+    expect(session.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("skips active sessions that inherit a channel default model", async () => {
+    const session = {
+      sessionId: "session-channel-default",
+      setModel: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    };
+    createSessionMock.mockResolvedValue(session);
+    buildSystemContextMock.mockResolvedValue("context");
+    getActiveSessionIdMock.mockReturnValue(null);
+    getChannelConfigMock.mockReturnValue({ defaultModel: "gpt-4.1" });
+
+    const { createNewSession, getSessionForChat, startAgent, switchDefaultModel } =
+      await import("./agent");
+
+    await startAgent();
+    await createNewSession({ chatId: -200007 });
+    await switchDefaultModel("anthropic:claude-opus-4-6");
+
+    expect(session.setModel).not.toHaveBeenCalled();
+    expect(session.disconnect).not.toHaveBeenCalled();
+    expect(deleteSessionMock).not.toHaveBeenCalledWith("session-channel-default");
+    expect(getSessionForChat(-200007)).toBe(session);
   });
 });
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,7 @@ import {
 import { clearActiveSession, getActiveSessionId } from "./logging/conversations";
 import { VALID_REASONING_EFFORTS } from "./constants";
 import { getChannelConfig } from "./memory/db";
+import { parseQualifiedModel, buildProviderConfig } from "./providers";
 
 let client: CopilotClient | null = null;
 const sessions = new Map<number, CopilotSession>();
@@ -172,7 +173,8 @@ export async function getOrCreateSession(opts: CreateSessionOptions): Promise<Co
       );
 
       const desiredModel = getModelForChat(opts.chatId);
-      await resumed.setModel(desiredModel);
+      const { rawModel } = parseQualifiedModel(desiredModel);
+      await resumed.setModel(rawModel);
 
       sessions.set(opts.chatId, resumed);
       getLogger().info(
@@ -209,9 +211,14 @@ export async function createNewSession(opts: CreateSessionOptions): Promise<Copi
 
   const model = getModelForChat(opts.chatId);
 
-  log.info({ chatId: opts.chatId, model }, "Creating new Copilot session");
+  const sessionConfig = await buildSessionConfig(opts.chatId);
+  const { rawModel, providerKey } = parseQualifiedModel(model);
+  log.info(
+    { chatId: opts.chatId, model, rawModel, provider: providerKey ?? "copilot" },
+    "Creating new Copilot session",
+  );
 
-  const session = await client.createSession(await buildSessionConfig(opts.chatId));
+  const session = await client.createSession(sessionConfig);
 
   sessions.set(opts.chatId, session);
   log.info({ chatId: opts.chatId, sessionId: session.sessionId }, "Session created");
@@ -219,8 +226,12 @@ export async function createNewSession(opts: CreateSessionOptions): Promise<Copi
   return session;
 }
 
-export async function switchModel(chatId: number, model: string): Promise<void> {
-  sessionModels.set(chatId, model);
+export async function switchModel(chatId: number, qualifiedModel: string): Promise<void> {
+  const oldQualified = sessionModels.get(chatId) ?? getModelForChat(chatId);
+  const oldSelection = parseQualifiedModel(oldQualified);
+  const newSelection = parseQualifiedModel(qualifiedModel);
+
+  sessionModels.set(chatId, qualifiedModel);
   try {
     await persistSessionModelOverrides();
   } catch (err) {
@@ -228,18 +239,49 @@ export async function switchModel(chatId: number, model: string): Promise<void> 
   }
 
   const session = sessions.get(chatId);
-  if (session) {
-    await session.setModel(model);
-    getLogger().info({ chatId, model }, "Model switched");
+  if (!session) return;
+
+  // Same provider — just switch model in-place
+  if (oldSelection.providerKey === newSelection.providerKey) {
+    await session.setModel(newSelection.rawModel);
+    getLogger().info({ chatId, model: qualifiedModel }, "Model switched");
+    return;
   }
+
+  // Different provider — need session refresh (provider is session-level config)
+  getLogger().info(
+    {
+      chatId,
+      model: qualifiedModel,
+      oldProvider: oldSelection.providerKey,
+      newProvider: newSelection.providerKey,
+    },
+    "Provider changed, refreshing session",
+  );
+  await refreshSessionContext(chatId);
 }
 
 export async function switchDefaultModel(model: string): Promise<void> {
+  const previousSelections = new Map<number, ReturnType<typeof parseQualifiedModel>>();
+  for (const [chatId] of sessions) {
+    if (sessionModels.has(chatId)) continue;
+    if (getChannelConfig(chatId)?.defaultModel) continue;
+    previousSelections.set(chatId, parseQualifiedModel(getModelForChat(chatId)));
+  }
+
   config.copilot.model = model;
+  const { rawModel, providerKey } = parseQualifiedModel(model);
 
   for (const [chatId, session] of sessions) {
     if (sessionModels.has(chatId)) continue;
-    await session.setModel(model);
+    if (getChannelConfig(chatId)?.defaultModel) continue;
+    const oldSelection =
+      previousSelections.get(chatId) ?? parseQualifiedModel(getModelForChat(chatId));
+    if (oldSelection.providerKey !== providerKey) {
+      await refreshSessionContext(chatId);
+    } else {
+      await session.setModel(rawModel);
+    }
     getLogger().info({ chatId, model }, "Default model applied to active session");
   }
 }
@@ -517,7 +559,8 @@ export async function resumeSessionById(
   const resumed = await client.resumeSession(sessionId, await buildSessionConfig(chatId));
 
   const desiredModel = getModelForChat(chatId);
-  await resumed.setModel(desiredModel);
+  const { rawModel } = parseQualifiedModel(desiredModel);
+  await resumed.setModel(rawModel);
 
   sessions.set(chatId, resumed);
   log.info({ chatId, sessionId: resumed.sessionId }, "Resumed session via /sessions");
@@ -527,15 +570,18 @@ export async function resumeSessionById(
 
 async function buildSessionConfig(chatId: number) {
   const systemContext = await buildSystemContext(chatId);
-  const model = getModelForChat(chatId);
+  const qualifiedModel = getModelForChat(chatId);
+  const { rawModel, providerKey } = parseQualifiedModel(qualifiedModel);
+  const provider = providerKey ? buildProviderConfig(providerKey) : undefined;
 
   const reasoningEffort = getReasoningEffortForChat(chatId);
 
   return {
     clientName: "neo",
-    model,
+    model: rawModel,
     streaming: true,
     ...(reasoningEffort && { reasoningEffort }),
+    ...(provider && { provider }),
     systemMessage: { mode: "replace" as const, content: systemContext },
     tools: allTools,
     skillDirectories: config.copilot.skillDirectories,

--- a/src/bot.test.ts
+++ b/src/bot.test.ts
@@ -12,13 +12,19 @@ vi.mock("@github/copilot-sdk", () => ({
   defineTool: () => ({}),
 }));
 
-const { botHandlers, resolvePendingUserInputMock, getPendingUserInputMock, registerCommandsMock } =
-  vi.hoisted(() => ({
-    botHandlers: new Map<string, (ctx: any) => Promise<void>>(),
-    resolvePendingUserInputMock: vi.fn(),
-    getPendingUserInputMock: vi.fn(),
-    registerCommandsMock: vi.fn(async () => {}),
-  }));
+const {
+  botHandlers,
+  resolvePendingUserInputMock,
+  getPendingUserInputMock,
+  registerCommandsMock,
+  resetModelCallFailuresMock,
+} = vi.hoisted(() => ({
+  botHandlers: new Map<string, (ctx: any) => Promise<void>>(),
+  resolvePendingUserInputMock: vi.fn(),
+  getPendingUserInputMock: vi.fn(),
+  registerCommandsMock: vi.fn(async () => {}),
+  resetModelCallFailuresMock: vi.fn(),
+}));
 
 vi.mock("grammy", () => ({
   Bot: class MockBot {
@@ -95,6 +101,16 @@ vi.mock("./commands/reasoning.js", () => ({
   isReasoningCallback: vi.fn(() => false),
 }));
 
+vi.mock("./commands/session.js", () => ({
+  handleSessionCallback: vi.fn(),
+  isSessionCallback: vi.fn(() => false),
+}));
+
+vi.mock("./commands/jobs.js", () => ({
+  handleJobsCallback: vi.fn(),
+  isJobsCallback: vi.fn(() => false),
+}));
+
 vi.mock("./telegram/files.js", () => ({
   downloadTelegramFile: vi.fn(),
 }));
@@ -149,6 +165,10 @@ vi.mock("./hooks/error-state.js", () => ({
   consumeSessionErrorNotified: vi.fn(() => false),
 }));
 
+vi.mock("./hooks/error.js", () => ({
+  resetModelCallFailures: resetModelCallFailuresMock,
+}));
+
 afterEach(() => {
   botHandlers.clear();
   resolvePendingUserInputMock.mockReset();
@@ -187,5 +207,48 @@ describe("createBot", () => {
     expect(resolvePendingUserInputMock).toHaveBeenCalledWith(123, "/tmp/file");
     expect(reply).toHaveBeenCalledWith("Resuming task…");
     expect(replyWithChatAction).not.toHaveBeenCalled();
+  });
+
+  it("resets model-call retry state after a successful turn", async () => {
+    const { createBot } = await import("./bot");
+    const { getOrCreateSession } = await import("./agent.js");
+    await createBot();
+
+    const textHandler = botHandlers.get("message:text");
+    expect(textHandler).toBeTypeOf("function");
+
+    const sessionHandlers: Array<(event: any) => void> = [];
+    vi.mocked(getOrCreateSession).mockResolvedValue({
+      sessionId: "session-1",
+      on: vi.fn((handler: (event: any) => void) => {
+        sessionHandlers.push(handler);
+        return () => {};
+      }),
+      send: vi.fn(async () => {
+        for (const handler of sessionHandlers) {
+          handler({ type: "assistant.message", data: { content: "done" } });
+          handler({ type: "session.idle", data: {} });
+        }
+      }),
+    } as any);
+
+    const reply = vi.fn(async (text: string) => {
+      if (text === "Thinking...") return { message_id: 1 };
+      return {};
+    });
+    const replyWithChatAction = vi.fn(async () => {});
+
+    await textHandler?.({
+      chat: { id: 123 },
+      message: { text: "hello" },
+      reply,
+      replyWithChatAction,
+      api: {
+        editMessageText: vi.fn(async () => {}),
+        deleteMessage: vi.fn(async () => {}),
+      },
+    });
+
+    expect(resetModelCallFailuresMock).toHaveBeenCalledWith("session-1");
   });
 });

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -56,6 +56,7 @@ import {
 } from "./telegram/user-input";
 import { shouldSilenceSessionError } from "./telegram/session-errors";
 import { consumeSessionErrorNotified } from "./hooks/error-state";
+import { resetModelCallFailures } from "./hooks/error";
 
 async function sendAndWaitForSessionIdle(
   chatId: number,
@@ -559,6 +560,7 @@ async function handleMessage(
     await sendAndWaitForSessionIdle(chatId, session, async () => {
       await session.send({ prompt: text, attachments });
     });
+    resetModelCallFailures(sessionId);
 
     if (consumeAbortFlag(chatId)) {
       await clearLiveStatus();

--- a/src/commands/model-catalog.test.ts
+++ b/src/commands/model-catalog.test.ts
@@ -12,11 +12,29 @@ const { dataDir, listModelsMock, getClientMock } = vi.hoisted(() => ({
 vi.mock("../config.js", () => ({
   config: {
     paths: { data: dataDir },
+    providers: {
+      anthropicApiKey: undefined,
+      openaiApiKey: undefined,
+      custom: {
+        name: undefined,
+        type: undefined,
+        baseUrl: undefined,
+        apiKey: undefined,
+        bearerToken: undefined,
+      },
+    },
   },
 }));
 
 vi.mock("../agent.js", () => ({
   getClient: getClientMock,
+}));
+
+vi.mock("../logging/index.js", () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
 }));
 
 function createModel(
@@ -55,6 +73,7 @@ function createModel(
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   vi.resetModules();
   rmSync(dataDir, { recursive: true, force: true });
   listModelsMock.mockReset();
@@ -77,6 +96,8 @@ describe("loadModelCatalog", () => {
     expect(result.source).toBe("network");
     expect(result.stale).toBe(false);
     expect(result.models.map((m) => m.id)).toEqual(["gpt-4.1", "claude-opus-4.6", "gpt-5.4"]);
+    expect(result.models[0].provider).toBe("copilot");
+    expect(result.models[0].label).toBe("GPT-4.1 [copilot]");
     expect(result.models[0].supportsReasoningEffort).toBe(true);
     expect(result.models[0].supportedReasoningEfforts).toEqual(["low", "medium", "high"]);
     expect(result.models[0].defaultReasoningEffort).toBe("medium");
@@ -89,7 +110,8 @@ describe("loadModelCatalog", () => {
       join(dataDir, "copilot-models-cache.json"),
       `${JSON.stringify({
         fetchedAt: "2026-03-13T10:00:00.000Z",
-        models: [{ id: "gpt-5.4", label: "GPT-5.4" }],
+        providerSignature: "[]",
+        models: [{ id: "gpt-5.4", label: "GPT-5.4 [copilot]", provider: "copilot" }],
       })}\n`,
       "utf-8",
     );
@@ -100,8 +122,45 @@ describe("loadModelCatalog", () => {
     const result = await loadModelCatalog({ now: Date.parse("2026-03-13T12:00:00.000Z") });
 
     expect(result.source).toBe("cache");
-    expect(result.models).toEqual([{ id: "gpt-5.4", label: "GPT-5.4" }]);
+    expect(result.models).toEqual([
+      { id: "gpt-5.4", label: "GPT-5.4 [copilot]", provider: "copilot" },
+    ]);
     expect(listModelsMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a fresh cache when provider configuration changes", async () => {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      join(dataDir, "copilot-models-cache.json"),
+      `${JSON.stringify({
+        fetchedAt: "2026-03-13T10:00:00.000Z",
+        models: [{ id: "gpt-5.4", label: "GPT-5.4 [copilot]", provider: "copilot" }],
+      })}\n`,
+      "utf-8",
+    );
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [{ id: "gpt-4.1-mini" }],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { config } = await import("../config.js");
+    config.providers.openaiApiKey = "sk-openai-test";
+
+    listModelsMock.mockResolvedValue([createModel("gpt-5.4", "GPT-5.4")]);
+    getClientMock.mockReturnValue({ listModels: listModelsMock });
+
+    const { loadModelCatalog } = await import("./model-catalog");
+    const result = await loadModelCatalog({ now: Date.parse("2026-03-13T12:00:00.000Z") });
+
+    expect(result.source).toBe("network");
+    expect(result.models.map((m) => m.id)).toEqual(["gpt-5.4", "openai:gpt-4.1-mini"]);
+    expect(listModelsMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes stale cache from the Copilot SDK", async () => {
@@ -123,7 +182,7 @@ describe("loadModelCatalog", () => {
 
     expect(result.source).toBe("network");
     expect(result.models[0].id).toBe("gpt-5.4");
-    expect(result.models[0].label).toBe("GPT-5.4");
+    expect(result.models[0].label).toBe("GPT-5.4 [copilot]");
     expect(listModelsMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/commands/model-catalog.ts
+++ b/src/commands/model-catalog.ts
@@ -4,6 +4,13 @@ import type { ModelInfo } from "@github/copilot-sdk";
 import type { ReasoningEffort } from "../agent";
 import { getClient } from "../agent";
 import { config } from "../config";
+import {
+  getConfiguredProviders,
+  fetchProviderModels,
+  qualifyModel,
+  type ProviderEntry,
+} from "../providers";
+import { getLogger } from "../logging/index";
 
 const MODEL_CATALOG_TTL_MS = 24 * 60 * 60 * 1000;
 const MODEL_CATALOG_CACHE_FILE = join(config.paths.data, "copilot-models-cache.json");
@@ -11,6 +18,7 @@ const MODEL_CATALOG_CACHE_FILE = join(config.paths.data, "copilot-models-cache.j
 export interface AvailableModel {
   id: string;
   label: string;
+  provider: string;
   supportsReasoningEffort?: boolean;
   supportedReasoningEfforts?: ReasoningEffort[];
   defaultReasoningEffort?: ReasoningEffort;
@@ -18,6 +26,7 @@ export interface AvailableModel {
 
 interface ModelCatalogCache {
   fetchedAt: string;
+  providerSignature?: string;
   models: AvailableModel[];
 }
 
@@ -39,9 +48,25 @@ function isModelCatalogCache(value: unknown): value is ModelCatalogCache {
   const candidate = value as Record<string, unknown>;
   return (
     typeof candidate.fetchedAt === "string" &&
+    (candidate.providerSignature === undefined ||
+      typeof candidate.providerSignature === "string") &&
     Array.isArray(candidate.models) &&
     candidate.models.every(isAvailableModel)
   );
+}
+
+function getProviderCatalogSignature(): string {
+  const providers = getConfiguredProviders()
+    .map((provider) => ({
+      key: provider.key,
+      label: provider.label,
+      type: provider.type,
+      baseUrl: provider.baseUrl,
+      authMode: provider.bearerToken ? "bearer" : provider.apiKey ? "api-key" : "none",
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  return JSON.stringify(providers);
 }
 
 async function readModelCatalogCache(): Promise<ModelCatalogCache | null> {
@@ -66,12 +91,13 @@ function normalizeModel(value: ModelInfo): AvailableModel | null {
   const id = value.id.trim();
   if (!id) return null;
 
-  const label = value.name.trim() || id;
+  const label = `${value.name.trim() || id} [copilot]`;
   const supportsReasoningEffort = value.capabilities?.supports?.reasoningEffort ?? false;
 
   return {
     id,
     label,
+    provider: "copilot",
     ...(supportsReasoningEffort && {
       supportsReasoningEffort: true,
       supportedReasoningEfforts: value.supportedReasoningEfforts,
@@ -80,15 +106,13 @@ function normalizeModel(value: ModelInfo): AvailableModel | null {
   };
 }
 
-async function fetchModelCatalogFromCopilot(forceRefresh = false): Promise<ModelCatalogCache> {
+async function fetchCopilotModels(forceRefresh: boolean): Promise<AvailableModel[]> {
   const client = getClient();
   if (!client) {
     throw new Error("Copilot client is not started");
   }
 
   if (forceRefresh) {
-    // SDK caches models for the client's lifetime with no public invalidation API.
-    // Null out the private cache so listModels() re-fetches from the server.
     (client as unknown as Record<string, unknown>).modelsCache = null;
   }
 
@@ -98,9 +122,60 @@ async function fetchModelCatalogFromCopilot(forceRefresh = false): Promise<Model
     throw new Error("Copilot models response did not contain any usable models");
   }
 
+  return models;
+}
+
+async function fetchBYOKModels(provider: ProviderEntry): Promise<AvailableModel[]> {
+  const models = await fetchProviderModels(provider);
+  return models.map((m) => ({
+    id: qualifyModel(provider.key, m.id),
+    label: `${m.name} [${provider.label}]`,
+    provider: provider.key,
+  }));
+}
+
+async function fetchAllModels(forceRefresh: boolean): Promise<ModelCatalogCache> {
+  const log = getLogger();
+  const providers = getConfiguredProviders();
+
+  let copilotModels: AvailableModel[] = [];
+  let copilotError: unknown = null;
+
+  try {
+    copilotModels = await fetchCopilotModels(forceRefresh);
+  } catch (err) {
+    copilotError = err;
+    log.warn({ err }, "Failed to fetch Copilot models");
+  }
+
+  const byokResults = await Promise.all(
+    providers.map(async (provider) => {
+      try {
+        return await fetchBYOKModels(provider);
+      } catch (err) {
+        log.warn({ provider: provider.key, err }, "Failed to fetch BYOK models");
+        return [];
+      }
+    }),
+  );
+
+  const byokModels = byokResults.flat();
+
+  if (copilotModels.length === 0 && byokModels.length === 0) {
+    if (copilotError) throw copilotError;
+    throw new Error("No models available from any provider");
+  }
+
+  // Copilot first, then BYOK providers sorted alphabetically by provider key
+  const sortedByok = [...byokModels].sort((a, b) => {
+    if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
+    return a.id.localeCompare(b.id);
+  });
+
   return {
     fetchedAt: new Date().toISOString(),
-    models,
+    providerSignature: getProviderCatalogSignature(),
+    models: [...copilotModels, ...sortedByok],
   };
 }
 
@@ -116,8 +191,14 @@ export async function loadModelCatalog(options?: {
 }): Promise<ModelCatalogResult> {
   const now = options?.now ?? Date.now();
   const cache = await readModelCatalogCache();
+  const providerSignature = getProviderCatalogSignature();
 
-  if (!options?.forceRefresh && cache && isFresh(cache.fetchedAt, now)) {
+  if (
+    !options?.forceRefresh &&
+    cache &&
+    isFresh(cache.fetchedAt, now) &&
+    cache.providerSignature === providerSignature
+  ) {
     return {
       fetchedAt: cache.fetchedAt,
       models: cache.models,
@@ -127,7 +208,7 @@ export async function loadModelCatalog(options?: {
   }
 
   try {
-    const fresh = await fetchModelCatalogFromCopilot(options?.forceRefresh);
+    const fresh = await fetchAllModels(options?.forceRefresh ?? false);
     await writeModelCatalogCache(fresh);
     return {
       fetchedAt: fresh.fetchedAt,

--- a/src/commands/model-context.test.ts
+++ b/src/commands/model-context.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { getModelForChatMock, getReasoningEffortForChatMock, getChannelConfigMock } = vi.hoisted(
   () => ({
@@ -16,12 +16,29 @@ vi.mock("../agent.js", () => ({
 }));
 
 vi.mock("../config.js", () => ({
-  config: { copilot: { model: "gpt-4.1" } },
+  config: {
+    copilot: { model: "gpt-4.1" },
+    providers: {
+      anthropicApiKey: undefined,
+      openaiApiKey: undefined,
+      custom: {
+        name: undefined,
+        type: undefined,
+        baseUrl: undefined,
+        apiKey: undefined,
+        bearerToken: undefined,
+      },
+    },
+  },
 }));
 
 vi.mock("../memory/db.js", () => ({
   getChannelConfig: getChannelConfigMock,
 }));
+
+afterEach(() => {
+  vi.resetModules();
+});
 
 describe("formatChatModelContextMarkdown", () => {
   it("shows reasoning effort override when set", async () => {
@@ -34,6 +51,8 @@ describe("formatChatModelContextMarkdown", () => {
       overrideActive: true,
       reasoningEffort: "high",
       channelDefaultReasoningEffort: null,
+      provider: "copilot",
+      configuredProviders: ["copilot"],
     });
 
     expect(result).toContain("Reasoning effort: `high` (override active)");
@@ -49,6 +68,8 @@ describe("formatChatModelContextMarkdown", () => {
       overrideActive: false,
       reasoningEffort: undefined,
       channelDefaultReasoningEffort: null,
+      provider: "copilot",
+      configuredProviders: ["copilot"],
     });
 
     expect(result).toContain("Reasoning effort: model default");
@@ -64,6 +85,8 @@ describe("formatChatModelContextMarkdown", () => {
       overrideActive: false,
       reasoningEffort: undefined,
       channelDefaultReasoningEffort: null,
+      provider: "copilot",
+      configuredProviders: ["copilot"],
     });
 
     expect(result).toContain("Channel default: `gpt-5.4`");
@@ -80,6 +103,8 @@ describe("formatChatModelContextMarkdown", () => {
       overrideActive: true,
       reasoningEffort: undefined,
       channelDefaultReasoningEffort: null,
+      provider: "copilot",
+      configuredProviders: ["copilot"],
     });
 
     expect(result).toContain("Channel default: `gpt-5.4`");
@@ -96,9 +121,47 @@ describe("formatChatModelContextMarkdown", () => {
       overrideActive: false,
       reasoningEffort: "medium",
       channelDefaultReasoningEffort: "medium",
+      provider: "copilot",
+      configuredProviders: ["copilot"],
     });
 
     expect(result).toContain("Reasoning effort: `medium` (channel default)");
+  });
+
+  it("shows provider info and available providers", async () => {
+    const { formatChatModelContextMarkdown } = await import("./model-context");
+
+    const result = formatChatModelContextMarkdown({
+      defaultModel: "gpt-4.1",
+      channelDefaultModel: null,
+      currentModel: "anthropic:claude-opus-4-6",
+      overrideActive: true,
+      reasoningEffort: undefined,
+      channelDefaultReasoningEffort: null,
+      provider: "anthropic",
+      configuredProviders: ["copilot", "anthropic", "openai"],
+    });
+
+    expect(result).toContain("Provider: anthropic");
+    expect(result).toContain("Available providers: copilot, anthropic, openai");
+  });
+
+  it("hides available providers when only copilot", async () => {
+    const { formatChatModelContextMarkdown } = await import("./model-context");
+
+    const result = formatChatModelContextMarkdown({
+      defaultModel: "gpt-4.1",
+      channelDefaultModel: null,
+      currentModel: "gpt-4.1",
+      overrideActive: false,
+      reasoningEffort: undefined,
+      channelDefaultReasoningEffort: null,
+      provider: "copilot",
+      configuredProviders: ["copilot"],
+    });
+
+    expect(result).toContain("Provider: copilot");
+    expect(result).not.toContain("Available providers:");
   });
 });
 
@@ -117,5 +180,7 @@ describe("getChatModelContext", () => {
     expect(result.channelDefaultModel).toBe("gpt-5.4");
     expect(result.channelDefaultReasoningEffort).toBe("high");
     expect(result.overrideActive).toBe(false);
+    expect(result.provider).toBe("copilot");
+    expect(result.configuredProviders).toContain("copilot");
   });
 });

--- a/src/commands/model-context.ts
+++ b/src/commands/model-context.ts
@@ -1,6 +1,7 @@
 import { getModelForChat, getReasoningEffortForChat, type ReasoningEffort } from "../agent";
 import { config } from "../config";
 import { getChannelConfig } from "../memory/db";
+import { parseQualifiedModel, getConfiguredProviders } from "../providers";
 
 export type ChatModelContext = {
   defaultModel: string;
@@ -9,6 +10,8 @@ export type ChatModelContext = {
   overrideActive: boolean;
   reasoningEffort: ReasoningEffort | undefined;
   channelDefaultReasoningEffort: string | null;
+  provider: string;
+  configuredProviders: string[];
 };
 
 export function getChatModelContext(chatId: number): ChatModelContext {
@@ -18,9 +21,11 @@ export function getChatModelContext(chatId: number): ChatModelContext {
   const channelDefaultModel = channelConfig?.defaultModel ?? null;
   const channelDefaultReasoningEffort = channelConfig?.defaultReasoningEffort ?? null;
 
-  // Override is active when the resolved model differs from what
-  // the channel default (or global default) would give
   const effectiveDefault = channelDefaultModel ?? defaultModel;
+  const { providerKey } = parseQualifiedModel(currentModel);
+  const providers = getConfiguredProviders();
+  const allProviderKeys = ["copilot", ...providers.map((p) => p.key)];
+
   return {
     defaultModel,
     channelDefaultModel,
@@ -28,6 +33,8 @@ export function getChatModelContext(chatId: number): ChatModelContext {
     overrideActive: currentModel !== effectiveDefault,
     reasoningEffort: getReasoningEffortForChat(chatId),
     channelDefaultReasoningEffort,
+    provider: providerKey ?? "copilot",
+    configuredProviders: allProviderKeys,
   };
 }
 
@@ -43,6 +50,12 @@ export function formatChatModelContextMarkdown(context: ChatModelContext): strin
   } else {
     const source = context.channelDefaultModel ? "channel default" : "default";
     lines.push(`Current chat model: \`${context.currentModel}\` (using ${source})`);
+  }
+
+  lines.push(`Provider: ${context.provider}`);
+
+  if (context.configuredProviders.length > 1) {
+    lines.push(`Available providers: ${context.configuredProviders.join(", ")}`);
   }
 
   if (context.reasoningEffort) {

--- a/src/commands/model.test.ts
+++ b/src/commands/model.test.ts
@@ -35,6 +35,12 @@ afterEach(() => {
 
 describe("handleModel", () => {
   it("switches directly and shows reasoning info", async () => {
+    loadModelCatalogMock.mockResolvedValue({
+      fetchedAt: "2026-03-13T10:00:00.000Z",
+      models: [{ id: "gpt-5", label: "GPT-5 [copilot]", provider: "copilot" }],
+      stale: false,
+      source: "cache",
+    });
     getModelReasoningInfoMock.mockResolvedValue({
       supported: true,
       levels: ["low", "medium", "high"],
@@ -57,6 +63,12 @@ describe("handleModel", () => {
   });
 
   it("ignores the bot mention in group-chat commands", async () => {
+    loadModelCatalogMock.mockResolvedValue({
+      fetchedAt: "2026-03-13T10:00:00.000Z",
+      models: [{ id: "gpt-5", label: "GPT-5 [copilot]", provider: "copilot" }],
+      stale: false,
+      source: "cache",
+    });
     getModelReasoningInfoMock.mockResolvedValue(null);
 
     const { handleModel } = await import("./model");
@@ -72,6 +84,29 @@ describe("handleModel", () => {
     const text = reply.mock.calls[0][0] as string;
     expect(text).toContain("Session model switched to `gpt-5` for this chat only.");
     expect(text).toContain("not supported by this model");
+  });
+
+  it("rejects models not in the catalog", async () => {
+    loadModelCatalogMock.mockResolvedValue({
+      fetchedAt: "2026-03-13T10:00:00.000Z",
+      models: [{ id: "gpt-5", label: "GPT-5 [copilot]", provider: "copilot" }],
+      stale: false,
+      source: "cache",
+    });
+
+    const { handleModel } = await import("./model");
+    const reply = vi.fn();
+
+    await handleModel({
+      chat: { id: 42 },
+      message: { text: "/model anthropic:claude-invalid-model" },
+      reply,
+    } as never);
+
+    expect(switchModelMock).not.toHaveBeenCalled();
+    const text = reply.mock.calls[0][0] as string;
+    expect(text).toContain("Unknown model");
+    expect(text).toContain("claude-invalid-model");
   });
 
   it("replies with a paginated picker when no model name is provided", async () => {

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -21,6 +21,7 @@ interface ModelPickerState {
   fetchedAt: string;
   models: AvailableModel[];
   stale: boolean;
+  providers: string[];
 }
 
 const modelPickers = new Map<string, ModelPickerState>();
@@ -49,13 +50,16 @@ function buildModelPickerText(
   page: number,
   totalPages: number,
   stale: boolean,
+  providers: string[],
 ): string {
-  const lines = [
-    "Choose a model for this chat.",
-    `Current: ${currentModel}`,
-    `Catalog fetched: ${fetchedAt}`,
-    `Page ${page + 1} of ${totalPages}`,
-  ];
+  const lines = ["Choose a model for this chat.", `Current: ${currentModel}`];
+
+  if (providers.length > 0) {
+    lines.push(`Providers: ${providers.join(", ")}`);
+  }
+
+  lines.push(`Catalog fetched: ${fetchedAt}`);
+  lines.push(`Page ${page + 1} of ${totalPages}`);
 
   if (stale) {
     lines.push("Using stale cached catalog because GitHub refresh failed.");
@@ -132,6 +136,14 @@ function parseModelCallbackData(
   return null;
 }
 
+function uniqueProviders(models: AvailableModel[]): string[] {
+  const seen = new Set<string>();
+  for (const m of models) {
+    if (m.provider) seen.add(m.provider);
+  }
+  return [...seen];
+}
+
 function registerModelPicker(catalog: ModelCatalogResult, currentModel: string): string {
   pruneExpiredPickers();
   const pickerId = createPickerId();
@@ -141,6 +153,7 @@ function registerModelPicker(catalog: ModelCatalogResult, currentModel: string):
     fetchedAt: catalog.fetchedAt,
     models: catalog.models,
     stale: catalog.stale,
+    providers: uniqueProviders(catalog.models),
   });
   return pickerId;
 }
@@ -159,6 +172,7 @@ function getModelPickerMessage(pickerId: string, page: number) {
       safePage,
       totalPages,
       picker.stale,
+      picker.providers,
     ),
     reply_markup: buildModelPickerMarkup(pickerId, picker.models, safePage),
   };
@@ -221,9 +235,18 @@ export async function handleModel(ctx: Context) {
   }
 
   try {
-    await switchModel(ctx.chat!.id, model);
-    let reply = `Session model switched to \`${model}\` for this chat only.`;
-    reply += await buildReasoningNote(ctx.chat!.id, model);
+    const catalog = await loadModelCatalog();
+    const match = catalog.models.find((m) => m.id === model);
+    if (!match) {
+      await ctx.reply(`Unknown model: \`${model}\`\nUse /model to see available models.`, {
+        parse_mode: "Markdown",
+      });
+      return;
+    }
+
+    await switchModel(ctx.chat!.id, match.id);
+    let reply = `Session model switched to \`${match.id}\` for this chat only.`;
+    reply += await buildReasoningNote(ctx.chat!.id, match.id);
     await ctx.reply(reply, { parse_mode: "Markdown" });
   } catch (err) {
     await ctx.reply(`Failed to switch model: ${err}`);
@@ -276,6 +299,7 @@ export async function handleModelCallback(ctx: Context): Promise<boolean> {
       picker.models = catalog.models;
       picker.fetchedAt = catalog.fetchedAt;
       picker.stale = catalog.stale;
+      picker.providers = uniqueProviders(catalog.models);
 
       const nextMessage = getModelPickerMessage(parsed.pickerId, 0);
       if (nextMessage) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,13 @@ function defaultSkillDirectories() {
   );
 }
 
+function parseOptionalProviderType(raw: string | undefined): "openai" | "anthropic" | undefined {
+  const trimmed = raw?.trim().toLowerCase();
+  if (!trimmed) return undefined;
+  if (trimmed === "openai" || trimmed === "anthropic") return trimmed;
+  throw new Error(`NEO_PROVIDER_TYPE must be "openai" or "anthropic", got "${raw}"`);
+}
+
 function detectSystemctlScope(): "system" | "user" {
   const configuredScope = process.env.NEO_SYSTEMCTL_SCOPE?.trim();
   if (configuredScope === "user" || configuredScope === "system") {
@@ -282,6 +289,17 @@ export interface Config {
   };
   logging: {
     level: LogLevel;
+  };
+  providers: {
+    anthropicApiKey: string | undefined;
+    openaiApiKey: string | undefined;
+    custom: {
+      name: string | undefined;
+      type: "openai" | "anthropic" | undefined;
+      baseUrl: string | undefined;
+      apiKey: string | undefined;
+      bearerToken: string | undefined;
+    };
   };
   service: {
     systemdUnit: string;
@@ -493,6 +511,17 @@ function loadConfig(): Config {
           bufferExhaustionThreshold: managed.NEO_CONTEXT_BUFFER_EXHAUSTION_THRESHOLD,
         },
       },
+      providers: {
+        anthropicApiKey: optionalString(process.env.ANTHROPIC_API_KEY),
+        openaiApiKey: optionalString(process.env.OPENAI_API_KEY),
+        custom: {
+          name: optionalString(process.env.NEO_PROVIDER_NAME),
+          type: parseOptionalProviderType(process.env.NEO_PROVIDER_TYPE),
+          baseUrl: optionalString(process.env.NEO_PROVIDER_BASE_URL),
+          apiKey: optionalString(process.env.NEO_PROVIDER_API_KEY),
+          bearerToken: optionalString(process.env.NEO_PROVIDER_BEARER_TOKEN),
+        },
+      },
       browser: {
         defaultHeadless: optionalBoolean(process.env.NEO_BROWSER_HEADLESS, true),
         launchArgs: (process.env.NEO_BROWSER_LAUNCH_ARGS || "")
@@ -547,3 +576,11 @@ export function redactSettingValue(key: ManagedConfigKey, value: unknown): unkno
 }
 
 export const config = loadConfig();
+
+export function hasAnyProvider(): boolean {
+  return !!(
+    config.providers.anthropicApiKey ||
+    config.providers.openaiApiKey ||
+    config.providers.custom.baseUrl
+  );
+}

--- a/src/hooks/error.ts
+++ b/src/hooks/error.ts
@@ -1,25 +1,81 @@
 import type { ErrorOccurredHandler } from "./types";
 import { getLogger } from "../logging/index";
-import { markSessionErrorNotified } from "./error-state";
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (!error || typeof error !== "object") {
+    return { message: String(error) };
+  }
+  const obj = error as Record<string, unknown>;
+  const fields: Record<string, unknown> = {};
+  for (const key of ["message", "name", "stack", "code", "status", "statusCode", "error", "type"]) {
+    if (key in obj && obj[key] !== undefined) {
+      fields[key] = obj[key];
+    }
+  }
+  for (const key of Object.keys(obj)) {
+    if (!(key in fields)) {
+      fields[key] = obj[key];
+    }
+  }
+  if (Object.keys(fields).length > 0) return fields;
+  return { raw: String(error) };
+}
+
+function isTransientError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const obj = error as Record<string, unknown>;
+  // Only retry if we can confirm a transient error (timeout, rate limit, etc.)
+  const message = typeof obj.message === "string" ? obj.message : "";
+  const code = typeof obj.code === "string" ? obj.code : "";
+  return /timeout|ETIMEDOUT|ECONNRESET|rate.limit|429|503|502/i.test(`${message} ${code}`);
+}
+
+const modelCallFailures = new Map<string, number>();
+
+export function resetModelCallFailures(sessionId: string): void {
+  modelCallFailures.delete(sessionId);
+}
 
 export function errorOccurred(chatId: number): ErrorOccurredHandler {
   return async (input, invocation) => {
     const log = getLogger();
     log.warn(
-      { chatId, error: input.error, context: input.errorContext, recoverable: input.recoverable },
+      {
+        chatId,
+        error: serializeError(input.error),
+        context: input.errorContext,
+        recoverable: input.recoverable,
+      },
       "hook:error-occurred",
     );
 
     if (input.errorContext === "model_call" && input.recoverable) {
-      return { errorHandling: "retry" as const, retryCount: 2 };
+      // Only retry transient errors we can identify; abort immediately for
+      // opaque errors (e.g. auth failures from BYOK providers where the SDK
+      // passes an empty {} error object).
+      if (!isTransientError(input.error)) {
+        resetModelCallFailures(invocation.sessionId);
+        return { errorHandling: "abort" as const };
+      }
+
+      const key = invocation.sessionId;
+      const count = (modelCallFailures.get(key) ?? 0) + 1;
+      modelCallFailures.set(key, count);
+
+      if (count <= 2) {
+        return { errorHandling: "retry" as const };
+      }
+
+      // Retries exhausted — abort so the session error surfaces to the user
+      resetModelCallFailures(key);
+      return { errorHandling: "abort" as const };
     }
 
+    // Reset counter on non-model-call events
+    resetModelCallFailures(invocation.sessionId);
+
     if (!input.recoverable && input.errorContext !== "tool_execution") {
-      markSessionErrorNotified(invocation.sessionId);
-      return {
-        errorHandling: "abort" as const,
-        userNotification: `\u26a0\ufe0f Neo encountered a non-recoverable error: ${input.error}`,
-      };
+      return { errorHandling: "abort" as const };
     }
   };
 }

--- a/src/hooks/hooks.test.ts
+++ b/src/hooks/hooks.test.ts
@@ -45,11 +45,10 @@ vi.mock("../logging/anomalies.js", () => ({
 
 import { preToolUse } from "./pre-tool";
 import { postToolUse } from "./post-tool";
-import { errorOccurred } from "./error";
+import { errorOccurred, resetModelCallFailures } from "./error";
 import { sessionEnd } from "./session-lifecycle";
 import { sessionStart } from "./session-start";
 import { isJobRunning } from "../scheduler/job-runner";
-import { consumeSessionErrorNotified } from "./error-state";
 import { readDailyMemory, isChannelChat } from "../memory/daily";
 import { getRuntimeContextSection } from "../runtime/state";
 import { formatAnomaliesForContext } from "../logging/anomalies";
@@ -132,17 +131,67 @@ describe("postToolUse", () => {
 describe("errorOccurred", () => {
   const handler = errorOccurred(CHAT_ID);
 
-  beforeEach(() => {
-    consumeSessionErrorNotified(INVOCATION.sessionId);
-  });
-
-  it("retries recoverable model_call errors", async () => {
+  it("retries transient model_call errors", async () => {
+    const invocation = { sessionId: "test-retry-transient" };
     const result = await handler(
-      baseInput({ error: "timeout", errorContext: "model_call", recoverable: true }),
-      INVOCATION,
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
     );
 
-    expect(result).toEqual({ errorHandling: "retry", retryCount: 2 });
+    expect(result).toEqual({ errorHandling: "retry" });
+  });
+
+  it("aborts immediately for opaque model_call errors", async () => {
+    const invocation = { sessionId: "test-opaque" };
+    const result = await handler(
+      baseInput({ error: {}, errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+
+    expect(result).toEqual({ errorHandling: "abort" });
+  });
+
+  it("aborts after repeated transient model_call failures", async () => {
+    const invocation = { sessionId: "test-retry-exhaust" };
+    // First two calls retry
+    await handler(
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+    await handler(
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+
+    // Third call should abort
+    const result = await handler(
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+
+    expect(result).toEqual({ errorHandling: "abort" });
+  });
+
+  it("allows a fresh retry episode after the counter is reset", async () => {
+    const invocation = { sessionId: "test-retry-reset" };
+
+    await handler(
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+    await handler(
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+
+    resetModelCallFailures(invocation.sessionId);
+
+    const result = await handler(
+      baseInput({ error: new Error("timeout"), errorContext: "model_call", recoverable: true }),
+      invocation,
+    );
+
+    expect(result).toEqual({ errorHandling: "retry" });
   });
 
   it("does not retry non-recoverable model_call errors", async () => {
@@ -151,11 +200,7 @@ describe("errorOccurred", () => {
       INVOCATION,
     );
 
-    expect(result).toEqual({
-      errorHandling: "abort",
-      userNotification: expect.stringContaining("fatal"),
-    });
-    expect(consumeSessionErrorNotified(INVOCATION.sessionId)).toBe(true);
+    expect(result).toEqual({ errorHandling: "abort" });
   });
 
   it("does not notify user for tool_execution errors", async () => {
@@ -165,7 +210,6 @@ describe("errorOccurred", () => {
     );
 
     expect(result).toBeUndefined();
-    expect(consumeSessionErrorNotified(INVOCATION.sessionId)).toBe(false);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,10 @@ async function main() {
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));
 
+  process.on("unhandledRejection", (reason) => {
+    log.error({ err: reason }, "Unhandled promise rejection");
+  });
+
   log.info("Neo is online. Listening for messages.");
 }
 

--- a/src/providers.test.ts
+++ b/src/providers.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { configMock } = vi.hoisted(() => ({
+  configMock: {
+    providers: {
+      anthropicApiKey: undefined as string | undefined,
+      openaiApiKey: undefined as string | undefined,
+      custom: {
+        name: undefined as string | undefined,
+        type: undefined as "openai" | "anthropic" | undefined,
+        baseUrl: undefined as string | undefined,
+        apiKey: undefined as string | undefined,
+        bearerToken: undefined as string | undefined,
+      },
+    },
+  },
+}));
+
+vi.mock("./config.js", () => ({
+  config: configMock,
+}));
+
+vi.mock("./logging/index.js", () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  vi.resetModules();
+  configMock.providers.anthropicApiKey = undefined;
+  configMock.providers.openaiApiKey = undefined;
+  configMock.providers.custom.name = undefined;
+  configMock.providers.custom.type = undefined;
+  configMock.providers.custom.baseUrl = undefined;
+  configMock.providers.custom.apiKey = undefined;
+  configMock.providers.custom.bearerToken = undefined;
+});
+
+describe("detectProviders", () => {
+  it("returns empty when no provider keys are configured", async () => {
+    const { detectProviders } = await import("./providers");
+    expect(detectProviders()).toEqual([]);
+  });
+
+  it("detects Anthropic from API key", async () => {
+    configMock.providers.anthropicApiKey = "sk-ant-test";
+    const { detectProviders } = await import("./providers");
+    const providers = detectProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]).toEqual({
+      key: "anthropic",
+      label: "anthropic",
+      type: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant-test",
+    });
+  });
+
+  it("detects OpenAI from API key", async () => {
+    configMock.providers.openaiApiKey = "sk-test";
+    const { detectProviders } = await import("./providers");
+    const providers = detectProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]).toEqual({
+      key: "openai",
+      label: "openai",
+      type: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test",
+    });
+  });
+
+  it("detects custom provider from base URL", async () => {
+    configMock.providers.custom.name = "ollama";
+    configMock.providers.custom.type = "openai";
+    configMock.providers.custom.baseUrl = "http://localhost:11434/v1";
+    const { detectProviders } = await import("./providers");
+    const providers = detectProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]).toEqual({
+      key: "ollama",
+      label: "ollama",
+      type: "openai",
+      baseUrl: "http://localhost:11434/v1",
+      apiKey: undefined,
+      bearerToken: undefined,
+    });
+  });
+
+  it("detects multiple providers simultaneously", async () => {
+    configMock.providers.anthropicApiKey = "sk-ant-test";
+    configMock.providers.openaiApiKey = "sk-test";
+    const { detectProviders } = await import("./providers");
+
+    expect(detectProviders()).toHaveLength(2);
+  });
+});
+
+describe("parseQualifiedModel", () => {
+  it("parses a plain model ID as copilot", async () => {
+    const { parseQualifiedModel } = await import("./providers");
+    expect(parseQualifiedModel("gpt-4.1")).toEqual({
+      rawModel: "gpt-4.1",
+      providerKey: undefined,
+    });
+  });
+
+  it("parses a qualified model ID", async () => {
+    configMock.providers.anthropicApiKey = "sk-ant-test";
+    const { parseQualifiedModel, resetProviderCache } = await import("./providers");
+    resetProviderCache();
+
+    expect(parseQualifiedModel("anthropic:claude-opus-4-6")).toEqual({
+      rawModel: "claude-opus-4-6",
+      providerKey: "anthropic",
+    });
+  });
+
+  it("treats unknown prefix as part of model ID", async () => {
+    const { parseQualifiedModel } = await import("./providers");
+    expect(parseQualifiedModel("unknown:some-model")).toEqual({
+      rawModel: "unknown:some-model",
+      providerKey: undefined,
+    });
+  });
+});
+
+describe("qualifyModel", () => {
+  it("returns plain model ID when no provider", async () => {
+    const { qualifyModel } = await import("./providers");
+    expect(qualifyModel(undefined, "gpt-4.1")).toBe("gpt-4.1");
+  });
+
+  it("qualifies model with provider prefix", async () => {
+    const { qualifyModel } = await import("./providers");
+    expect(qualifyModel("anthropic", "claude-opus-4-6")).toBe("anthropic:claude-opus-4-6");
+  });
+});
+
+describe("buildProviderConfig", () => {
+  it("returns undefined for unknown provider", async () => {
+    const { buildProviderConfig } = await import("./providers");
+    expect(buildProviderConfig("nonexistent")).toBeUndefined();
+  });
+
+  it("builds provider config for Anthropic", async () => {
+    configMock.providers.anthropicApiKey = "sk-ant-test";
+    const { buildProviderConfig, resetProviderCache } = await import("./providers");
+    resetProviderCache();
+    const providerConfig = buildProviderConfig("anthropic");
+
+    expect(providerConfig).toEqual({
+      type: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant-test",
+    });
+  });
+
+  it("includes bearer token when configured", async () => {
+    configMock.providers.custom.name = "custom";
+    configMock.providers.custom.type = "openai";
+    configMock.providers.custom.baseUrl = "http://localhost:8080";
+    configMock.providers.custom.bearerToken = "my-token";
+    const { buildProviderConfig, resetProviderCache } = await import("./providers");
+    resetProviderCache();
+    const providerConfig = buildProviderConfig("custom");
+
+    expect(providerConfig).toEqual({
+      type: "openai",
+      baseUrl: "http://localhost:8080",
+      bearerToken: "my-token",
+    });
+  });
+});
+
+describe("fetchProviderModels", () => {
+  it("fetches Anthropic models", async () => {
+    const mockResponse = {
+      data: [
+        { id: "claude-opus-4-6", display_name: "Claude Opus 4.6" },
+        { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }),
+    );
+
+    const { fetchProviderModels } = await import("./providers");
+    const models = await fetchProviderModels({
+      key: "anthropic",
+      label: "anthropic",
+      type: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant-test",
+    });
+
+    expect(models).toEqual([
+      { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    ]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("sends bearer auth for Anthropics-compatible custom providers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [{ id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" }],
+        }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchProviderModels } = await import("./providers");
+    await fetchProviderModels({
+      key: "custom-anthropic",
+      label: "custom-anthropic",
+      type: "anthropic",
+      baseUrl: "https://anthropic-proxy.example.com",
+      bearerToken: "my-bearer-token",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://anthropic-proxy.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "anthropic-version": "2023-06-01",
+          Authorization: "Bearer my-bearer-token",
+        }),
+      }),
+    );
+    const requestInit = fetchMock.mock.calls[0]?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
+    expect(requestInit?.headers).not.toHaveProperty("x-api-key");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches and filters OpenAI models", async () => {
+    const mockResponse = {
+      data: [
+        { id: "gpt-4.1" },
+        { id: "gpt-4.1-mini" },
+        { id: "dall-e-3" },
+        { id: "text-embedding-3-large" },
+        { id: "o3-mini" },
+      ],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }),
+    );
+
+    const { fetchProviderModels } = await import("./providers");
+    const models = await fetchProviderModels({
+      key: "openai",
+      label: "openai",
+      type: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test",
+    });
+
+    expect(models.map((m) => m.id)).toEqual(["gpt-4.1", "gpt-4.1-mini", "o3-mini"]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns all models for custom OpenAI-compatible providers", async () => {
+    const mockResponse = {
+      data: [{ id: "llama3" }, { id: "codellama" }],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }),
+    );
+
+    const { fetchProviderModels } = await import("./providers");
+    const models = await fetchProviderModels({
+      key: "ollama",
+      label: "ollama",
+      type: "openai",
+      baseUrl: "http://localhost:11434/v1",
+    });
+
+    expect(models).toEqual([
+      { id: "llama3", name: "llama3" },
+      { id: "codellama", name: "codellama" },
+    ]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns empty array on fetch failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      }),
+    );
+
+    const { fetchProviderModels } = await import("./providers");
+    const models = await fetchProviderModels({
+      key: "anthropic",
+      label: "anthropic",
+      type: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "invalid",
+    });
+
+    expect(models).toEqual([]);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,0 +1,192 @@
+import { config } from "./config";
+import { getLogger } from "./logging/index";
+
+export interface ProviderEntry {
+  key: string;
+  label: string;
+  type: "openai" | "anthropic";
+  baseUrl: string;
+  apiKey?: string;
+  bearerToken?: string;
+}
+
+export interface ProviderConfig {
+  type?: "openai" | "anthropic";
+  wireApi?: "completions" | "responses";
+  baseUrl: string;
+  apiKey?: string;
+  bearerToken?: string;
+}
+
+export interface ModelSelection {
+  rawModel: string;
+  providerKey: string | undefined;
+}
+
+export interface ProviderModelInfo {
+  id: string;
+  name: string;
+}
+
+let cachedProviders: ProviderEntry[] | null = null;
+
+export function detectProviders(): ProviderEntry[] {
+  const providers: ProviderEntry[] = [];
+
+  if (config.providers.anthropicApiKey) {
+    providers.push({
+      key: "anthropic",
+      label: "anthropic",
+      type: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: config.providers.anthropicApiKey,
+    });
+  }
+
+  if (config.providers.openaiApiKey) {
+    providers.push({
+      key: "openai",
+      label: "openai",
+      type: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: config.providers.openaiApiKey,
+    });
+  }
+
+  const custom = config.providers.custom;
+  if (custom.baseUrl) {
+    providers.push({
+      key: custom.name ?? "custom",
+      label: custom.name ?? "custom",
+      type: custom.type ?? "openai",
+      baseUrl: custom.baseUrl,
+      apiKey: custom.apiKey,
+      bearerToken: custom.bearerToken,
+    });
+  }
+
+  return providers;
+}
+
+export function getConfiguredProviders(): ProviderEntry[] {
+  if (!cachedProviders) {
+    cachedProviders = detectProviders();
+  }
+  return cachedProviders;
+}
+
+export function resetProviderCache(): void {
+  cachedProviders = null;
+}
+
+export function getProvider(key: string): ProviderEntry | undefined {
+  return getConfiguredProviders().find((p) => p.key === key);
+}
+
+export function buildProviderConfig(key: string): ProviderConfig | undefined {
+  const provider = getProvider(key);
+  if (!provider) return undefined;
+
+  return {
+    type: provider.type,
+    baseUrl: provider.baseUrl,
+    ...(provider.apiKey && { apiKey: provider.apiKey }),
+    ...(provider.bearerToken && { bearerToken: provider.bearerToken }),
+  };
+}
+
+export function parseQualifiedModel(qualifiedId: string): ModelSelection {
+  const colonIndex = qualifiedId.indexOf(":");
+  if (colonIndex === -1) {
+    return { rawModel: qualifiedId, providerKey: undefined };
+  }
+
+  const prefix = qualifiedId.slice(0, colonIndex);
+  const model = qualifiedId.slice(colonIndex + 1);
+
+  // Only treat as qualified if the prefix matches a known provider
+  const provider = getProvider(prefix);
+  if (provider) {
+    return { rawModel: model, providerKey: prefix };
+  }
+
+  // Not a known provider prefix — treat the whole string as a model ID
+  return { rawModel: qualifiedId, providerKey: undefined };
+}
+
+export function qualifyModel(providerKey: string | undefined, modelId: string): string {
+  if (!providerKey) return modelId;
+  return `${providerKey}:${modelId}`;
+}
+
+const OPENAI_CHAT_PREFIXES = ["gpt-", "o1-", "o3-", "o4-", "chatgpt-"];
+
+export async function fetchProviderModels(provider: ProviderEntry): Promise<ProviderModelInfo[]> {
+  const log = getLogger();
+
+  try {
+    if (provider.type === "anthropic") {
+      return await fetchAnthropicModels(provider);
+    }
+    return await fetchOpenAIModels(provider);
+  } catch (err) {
+    log.warn({ provider: provider.key, err }, "Failed to fetch models from provider");
+    return [];
+  }
+}
+
+async function fetchAnthropicModels(provider: ProviderEntry): Promise<ProviderModelInfo[]> {
+  const url = `${provider.baseUrl}/v1/models`;
+  const headers: Record<string, string> = {
+    "anthropic-version": "2023-06-01",
+  };
+  if (provider.bearerToken) {
+    headers["Authorization"] = `Bearer ${provider.bearerToken}`;
+  } else if (provider.apiKey) {
+    headers["x-api-key"] = provider.apiKey;
+  }
+
+  const response = await fetch(url, { headers, signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) {
+    throw new Error(`Anthropic API returned ${response.status}`);
+  }
+
+  const body = (await response.json()) as { data?: { id: string; display_name?: string }[] };
+  if (!body.data || !Array.isArray(body.data)) return [];
+
+  return body.data
+    .filter((m) => m.id && typeof m.id === "string")
+    .map((m) => ({
+      id: m.id,
+      name: m.display_name ?? m.id,
+    }));
+}
+
+async function fetchOpenAIModels(provider: ProviderEntry): Promise<ProviderModelInfo[]> {
+  const url = `${provider.baseUrl}/models`;
+  const headers: Record<string, string> = {};
+  if (provider.bearerToken) {
+    headers["Authorization"] = `Bearer ${provider.bearerToken}`;
+  } else if (provider.apiKey) {
+    headers["Authorization"] = `Bearer ${provider.apiKey}`;
+  }
+
+  const response = await fetch(url, { headers, signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) {
+    throw new Error(`OpenAI-compatible API returned ${response.status}`);
+  }
+
+  const body = (await response.json()) as { data?: { id: string }[] };
+  if (!body.data || !Array.isArray(body.data)) return [];
+
+  // For well-known OpenAI, filter to chat models; for custom providers, return all
+  if (provider.key === "openai") {
+    return body.data
+      .filter((m) => m.id && OPENAI_CHAT_PREFIXES.some((p) => m.id.startsWith(p)))
+      .map((m) => ({ id: m.id, name: m.id }));
+  }
+
+  return body.data
+    .filter((m) => m.id && typeof m.id === "string")
+    .map((m) => ({ id: m.id, name: m.id }));
+}


### PR DESCRIPTION
## Summary

Add bring-your-own-key provider support so Neo can surface and switch between Copilot, OpenAI, Anthropic, and custom OpenAI-compatible model catalogs.

## Major changes

- Add provider config/env parsing plus provider-aware model qualification, catalog loading, and session creation/switching.
- Update /model and model-context flows to show provider metadata, validate requested models against the catalog, and refresh sessions when the provider changes.
- Harden model-call error handling for BYOK failures, reset retry state after successful turns, and document the new env vars and usage in the README.

## Tests

- `npm run check`
