### PR TITLE
fix: harden system chat model updates

### DIFF
--- a/src/tools/system.test.ts
+++ b/src/tools/system.test.ts
@@ -6,19 +6,25 @@ vi.mock("@github/copilot-sdk", () => ({
 
 const {
   clearPerChatModelOverrideMock,
+  clearReasoningEffortMock,
   getPerChatModelOverrideMock,
+  getReasoningEffortForChatMock,
   refreshSessionContextMock,
   switchModelMock,
   getChannelConfigMock,
   upsertChannelConfigMock,
+  loadModelCatalogMock,
   createAuditTimerMock,
 } = vi.hoisted(() => ({
   clearPerChatModelOverrideMock: vi.fn(),
+  clearReasoningEffortMock: vi.fn(),
   getPerChatModelOverrideMock: vi.fn(),
+  getReasoningEffortForChatMock: vi.fn(),
   refreshSessionContextMock: vi.fn(),
   switchModelMock: vi.fn(),
   getChannelConfigMock: vi.fn(),
   upsertChannelConfigMock: vi.fn(),
+  loadModelCatalogMock: vi.fn(),
   createAuditTimerMock: vi.fn(() => ({
     complete: vi.fn(),
   })),
@@ -26,9 +32,15 @@ const {
 
 vi.mock("../agent.js", () => ({
   clearPerChatModelOverride: clearPerChatModelOverrideMock,
+  clearReasoningEffort: clearReasoningEffortMock,
   getPerChatModelOverride: getPerChatModelOverrideMock,
+  getReasoningEffortForChat: getReasoningEffortForChatMock,
   refreshSessionContext: refreshSessionContextMock,
   switchModel: switchModelMock,
+}));
+
+vi.mock("../commands/model-catalog.js", () => ({
+  loadModelCatalog: loadModelCatalogMock,
 }));
 
 vi.mock("../memory/db.js", () => ({
@@ -68,6 +80,33 @@ const invocation = { sessionId: "test-session" };
 describe("system tool — set_chat_model", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    loadModelCatalogMock.mockResolvedValue({
+      models: [
+        {
+          id: "claude-opus-4-6",
+          label: "Claude Opus 4.6",
+          provider: "copilot",
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["medium", "high"],
+          defaultReasoningEffort: "medium",
+        },
+        {
+          id: "gpt-4.1",
+          label: "GPT-4.1",
+          provider: "copilot",
+          supportsReasoningEffort: false,
+          supportedReasoningEfforts: [],
+        },
+        {
+          id: "gpt-5.4",
+          label: "GPT-5.4",
+          provider: "copilot",
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium"],
+          defaultReasoningEffort: "medium",
+        },
+      ],
+    });
   });
 
   it("requires chat_id", async () => {
@@ -78,6 +117,17 @@ describe("system tool — set_chat_model", () => {
   it("requires model", async () => {
     const result = await handler({ action: "set_chat_model", chat_id: -100 }, invocation);
     expect(result).toContain("model is required");
+  });
+
+  it("rejects unknown models before persisting them", async () => {
+    const result = await handler(
+      { action: "set_chat_model", chat_id: -100, model: "unknown-model" },
+      invocation,
+    );
+
+    expect(result).toContain("unknown model: unknown-model");
+    expect(upsertChannelConfigMock).not.toHaveBeenCalled();
+    expect(switchModelMock).not.toHaveBeenCalled();
   });
 
   it("sets channel default and clears per-chat override by default", async () => {
@@ -118,6 +168,21 @@ describe("system tool — set_chat_model", () => {
     expect(parsed.previousPerChatOverride).toBeUndefined();
   });
 
+  it("clears incompatible reasoning overrides when setting a channel default", async () => {
+    getPerChatModelOverrideMock.mockReturnValue(undefined);
+    getReasoningEffortForChatMock.mockReturnValue("high");
+
+    const result = await handler(
+      { action: "set_chat_model", chat_id: -200, model: "gpt-4.1" },
+      invocation,
+    );
+    const parsed = JSON.parse(result);
+
+    expect(clearReasoningEffortMock).toHaveBeenCalledWith(-200);
+    expect(parsed.previousReasoningEffort).toBe("high");
+    expect(parsed.reasoningEffortCleared).toBe(true);
+  });
+
   it("sets per-chat override when scope is chat", async () => {
     getPerChatModelOverrideMock.mockReturnValue("gpt-4.1");
 
@@ -146,6 +211,36 @@ describe("system tool — set_chat_model", () => {
 
     expect(switchModelMock).toHaveBeenCalledWith(456, "gpt-5.4");
     expect(parsed.previousPerChatModel).toBeNull();
+  });
+
+  it("clears incompatible reasoning overrides when setting a per-chat model", async () => {
+    getPerChatModelOverrideMock.mockReturnValue(undefined);
+    getReasoningEffortForChatMock.mockReturnValue("high");
+
+    const result = await handler(
+      { action: "set_chat_model", chat_id: 456, model: "gpt-5.4", scope: "chat" },
+      invocation,
+    );
+    const parsed = JSON.parse(result);
+
+    expect(switchModelMock).toHaveBeenCalledWith(456, "gpt-5.4");
+    expect(clearReasoningEffortMock).toHaveBeenCalledWith(456);
+    expect(parsed.previousReasoningEffort).toBe("high");
+    expect(parsed.reasoningEffortCleared).toBe(true);
+  });
+
+  it("keeps compatible reasoning overrides when the new model supports them", async () => {
+    getPerChatModelOverrideMock.mockReturnValue(undefined);
+    getReasoningEffortForChatMock.mockReturnValue("medium");
+
+    const result = await handler(
+      { action: "set_chat_model", chat_id: 456, model: "gpt-5.4", scope: "chat" },
+      invocation,
+    );
+    const parsed = JSON.parse(result);
+
+    expect(clearReasoningEffortMock).not.toHaveBeenCalled();
+    expect(parsed.reasoningEffortCleared).toBeUndefined();
   });
 });
 

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -15,10 +15,13 @@ import {
 } from "../runtime/state";
 import {
   clearPerChatModelOverride,
+  clearReasoningEffort,
   getPerChatModelOverride,
+  getReasoningEffortForChat,
   refreshSessionContext,
   switchModel,
 } from "../agent";
+import { loadModelCatalog, type AvailableModel } from "../commands/model-catalog";
 import { getChannelConfig, upsertChannelConfig } from "../memory/db";
 
 function formatUptime(seconds: number): string {
@@ -33,6 +36,28 @@ function formatUptime(seconds: number): string {
   if (minutes > 0) parts.push(`${minutes}m`);
   parts.push(`${secs}s`);
   return parts.join(" ");
+}
+
+async function loadValidatedModel(modelId: string): Promise<AvailableModel | null> {
+  const catalog = await loadModelCatalog();
+  return catalog.models.find((model) => model.id === modelId) ?? null;
+}
+
+async function clearIncompatibleReasoningOverride(chatId: number, model: AvailableModel) {
+  const currentEffort = getReasoningEffortForChat(chatId);
+  if (!currentEffort) return null;
+
+  const supportedLevels = model.supportedReasoningEfforts ?? [];
+  const supportsReasoningEffort = model.supportsReasoningEffort ?? false;
+  if (supportsReasoningEffort && supportedLevels.includes(currentEffort)) {
+    return null;
+  }
+
+  await clearReasoningEffort(chatId);
+  return {
+    previousReasoningEffort: currentEffort,
+    reasoningEffortCleared: true,
+  };
 }
 
 export const systemTool = defineTool("system", {
@@ -230,11 +255,22 @@ export const systemTool = defineTool("system", {
           const chatId = args.chat_id;
           const modelId = args.model;
           const scope = args.scope ?? "channel";
+          const validatedModel = await loadValidatedModel(modelId);
+
+          if (!validatedModel) {
+            const result = `Error: unknown model: ${modelId}. Use /model to see available models.`;
+            audit.complete(result);
+            return result;
+          }
 
           if (scope === "chat") {
             // Per-chat override (like /model) — temporary, chat-specific
             const previousOverride = getPerChatModelOverride(chatId);
             await switchModel(chatId, modelId);
+            const reasoningChange = await clearIncompatibleReasoningOverride(
+              chatId,
+              validatedModel,
+            );
 
             const result = JSON.stringify(
               {
@@ -243,6 +279,7 @@ export const systemTool = defineTool("system", {
                 scope: "chat",
                 perChatModel: modelId,
                 previousPerChatModel: previousOverride ?? null,
+                ...reasoningChange,
                 restartTriggered: false,
               },
               null,
@@ -263,11 +300,13 @@ export const systemTool = defineTool("system", {
             await refreshSessionContext(chatId);
           }
 
+          const reasoningChange = await clearIncompatibleReasoningOverride(chatId, validatedModel);
           const resultPayload: Record<string, unknown> = {
             applied: true,
             chatId,
             scope: "channel",
             channelDefaultModel: modelId,
+            ...reasoningChange,
             restartTriggered: false,
           };
           if (previousOverride) {


### PR DESCRIPTION
### Motivation
- Reviews pointed out `system.set_chat_model` could persist arbitrary unknown model strings and accidentally clobber channel defaults when only a per-chat override was intended. 
- A chat-scoped model switch did not clear reasoning-effort overrides that are incompatible with the newly selected model, which could produce invalid session configs. 
- Tests needed regression coverage for unknown-model rejection and reasoning-compatibility behavior to prevent future regressions.

### Description
- Validate requested model IDs against the live catalog before persisting by adding `loadValidatedModel()` which uses `loadModelCatalog()` and returning an error if the model is unknown. 
- Add `clearIncompatibleReasoningOverride()` which checks `getReasoningEffortForChat()` and clears incompatible reasoning overrides via `clearReasoningEffort()` and include its result in the tool response for both chat-scoped and channel-scoped changes. 
- Update `src/tools/system.ts` to import `loadModelCatalog`, `clearReasoningEffort`, and `getReasoningEffortForChat` and wire the new validation and cleanup into the `set_chat_model` flow. 
- Expand `src/tools/system.test.ts` to mock the model catalog and add tests for unknown-model rejection, clearing incompatible reasoning overrides (chat and channel), and keeping compatible overrides.

### Testing
- Ran `npm run test -- src/tools/system.test.ts` and the file-level suite passed (`16 passed`).
- Ran `npm run lint`, `npm run fmt:check`, and `npm run typecheck` and they all succeeded after formatting fixes. 
- Ran `npm run check` (full project checks) which cannot fully pass in this environment because several existing tests require the `node:sqlite` builtin which is unavailable here, so the full suite failed for environment reasons unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beab3a67dc8330ba8be16996477410)